### PR TITLE
Fix bootstrap script and bindep for F35

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -1,9 +1,13 @@
-
 build-essential [platform:dpkg]
+gcc [platform:rpm]
 libffi-dev [platform:dpkg]
 libffi-devel [platform:rpm]
 python3
 python3-dev [platform:dpkg]
 python3-devel [platform:rpm]
+libvirt-devel [platform:rpm]
+ruby-devel [platform:rpm]
+redhat-rpm-config [platform:rpm]
+vagrant [platform:rpm]
+rsync [platform:rpm]
 libvirt-daemon
-vagrant

--- a/bootstrap-repo.sh
+++ b/bootstrap-repo.sh
@@ -4,7 +4,9 @@
 pip install bindep wheel
 set -x
 which dpkg && bindep -b | xargs sudo apt install
-which rpm && bindep -b | xargs dnf apt install
+# Don't install weak deps, as that will pull in vagrant-libvirt, which we want
+# to install manually later on.
+which rpm && bindep -b | xargs sudo dnf -y --setopt=install_weak_deps=False install
 #pip install ansible=2.9
 pip install ansible\<5 ansible-core\<2.12.0 \
     molecule molecule-vagrant python-vagrant netaddr molecule-openstack openstacksdk
@@ -12,4 +14,16 @@ pip install ansible\<5 ansible-core\<2.12.0 \
 pip install libvirt-python
 which vagrant && vagrant plugin install vagrant-libvirt
 git submodule update --init --recursive
+# At least on Fedora, the user running this needs to be in the libvirt group to
+# avoid authentication errors when running `molecule create`
+if [[ `cat /etc/redhat-release 2> /dev/null` =~ 'Fedora' ]]
+then
+    if [[ `groups` =~ 'libvirt' ]]
+    then
+        true
+    else
+        echo 'You need to be part of the libvirt group for this to work.'
+        exit
+    fi
+fi
 set +x

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -27,9 +27,7 @@ platforms:
     provider_options:
       cpu_mode: 'host-passthrough'
       nested: true
-    provider_raw_config_args:
-      - cputopology :sockets => '1', :cores => '4', :threads => '2'
-      - random :model => 'random'
+      machine_type: 'q35'
     groups:
       - controller
       - switch
@@ -39,9 +37,7 @@ platforms:
     provider_options:
       cpu_mode: 'host-passthrough'
       nested: true
-    provider_raw_config_args:
-      - cputopology :sockets => '1', :cores => '4', :threads => '2'
-      - random :model => 'random'
+      machine_type: 'q35'
     groups:
       - compute
       - peers


### PR DESCRIPTION
* Fix the dnf command line typo
* Don't install weak deps with dnf (see inline comment)
* Add needed dependencies to bindep.txt
* Add check for user being in the 'libvirt' group
* Switch machine type to q35 and remove topology, at least one of
  these seems necessary for the creates VMs to boot properly.