### PR TITLE
update default c9s iamge to use generic box

### DIFF
--- a/ansible/deploy_multinode_devstack.yaml
+++ b/ansible/deploy_multinode_devstack.yaml
@@ -39,6 +39,10 @@
     - common
     - vdpa
 
+# note that syncing the cache need to happen after the devstack_common
+# role has run to ensure rsync is installed on the target hosts.
+# when the cacheing is refarctored into push cache and pull cache roles
+# we can relax this requriement by having the cache roles ensure its installed.
 - name: push remote cache dirs
   hosts: all
   tags:

--- a/ansible/roles/devstack_common/defaults/main.yml
+++ b/ansible/roles/devstack_common/defaults/main.yml
@@ -17,12 +17,14 @@ debian_pkg_install:
   - sudo
   - wget
   - nano
+  - rsync
 redhat_pkg_install:
   - git-core
   - sudo
   - acl
   - wget
   - nano
+  - rsync
 debian_pkg_remove:
   - cloud-init
   - python3-pyyaml

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -19,7 +19,7 @@ driver:
   parallel: true
   # vagrant box to use by default
   # Defaults to 'generic/alpine310'
-  default_box: 'alvistack/centos-9-stream'
+  default_box: 'generic/centos9s'
 platforms:
   - name: controller
     memory: 8192


### PR DESCRIPTION
This change replaces the customised centos 9 stream
image with one provided by the generic vagrant box
provider.

currently the code to disable the customised image repos
is not removed but that can be remvoed in the future if
we do not encounter any issues with the new generic image.
