### PR TITLE
add olm installation

### DIFF
--- a/ansible/roles/ensure_microshift/defaults/main.yml
+++ b/ansible/roles/ensure_microshift/defaults/main.yml
@@ -13,3 +13,7 @@ microshift_volumes:
   - "/etc:/etc"
 crio_os:  "CentOS_8_Stream"
 crio_version: "1.21"
+install_olm: yes
+repo_dir: /opt/stack
+operator_sdk_url: https://github.com/operator-framework/operator-sdk
+operator_sdk_version: v1.21.0

--- a/ansible/roles/ensure_microshift/tasks/main.yml
+++ b/ansible/roles/ensure_microshift/tasks/main.yml
@@ -117,3 +117,38 @@
         cat /var/lib/microshift/resources/kubeadmin/kubeconfig > /home/stack/.kube/config
         chown stack:stack /home/stack/.kube/config
 
+- name: install olm
+  when: install_olm | bool
+  tags: olm
+  become_user: stack
+  become: yes
+  block:
+    - name: install git
+      become: yes
+      become_user: root
+      package:
+        name: git
+        state: present
+    - name: clone operator-sdk
+      ansible.builtin.git:
+        repo: '{{operator_sdk_url}}'
+        dest: '{{repo_dir}}/operator-sdk'
+        version: '{{operator_sdk_version}}'
+    - name: install go
+      become: yes
+      become_user: root
+      package:
+        name: golang
+        state: present
+    - name: build  sdk
+      shell:
+        cmd: make build
+        chdir: '{{repo_dir}}/operator-sdk'
+    - name: remove olm if installed
+      shell:
+        cmd: build/operator-sdk olm uninstall
+        chdir: '{{repo_dir}}/operator-sdk'
+    - name: install olm with sdk
+      shell:
+        cmd: build/operator-sdk olm install
+        chdir: '{{repo_dir}}/operator-sdk'


### PR DESCRIPTION
microshift does not include olm by default
this change automates installing it via operator-sdk
