### PR TITLE
fix instance name and only uninstall olm if installed.

### DIFF
--- a/ansible/roles/ensure_microshift/tasks/main.yml
+++ b/ansible/roles/ensure_microshift/tasks/main.yml
@@ -144,10 +144,21 @@
       shell:
         cmd: make build
         chdir: '{{repo_dir}}/operator-sdk'
+    - name: check if olm is installed
+      shell:
+        cmd: build/operator-sdk olm status
+        chdir: '{{repo_dir}}/operator-sdk'
+      register: olm_status
+      failed_when:
+        - olm_status.rc != 0
+        - '"Failed to get OLM status: error getting installed OLM version" not in olm_status.stderr'
     - name: remove olm if installed
       shell:
         cmd: build/operator-sdk olm uninstall
         chdir: '{{repo_dir}}/operator-sdk'
+      register: uninstall_result
+      when:
+        - olm_status.rc == 0
     - name: install olm with sdk
       shell:
         cmd: build/operator-sdk olm install

--- a/molecule/microshift/molecule.yml
+++ b/molecule/microshift/molecule.yml
@@ -21,7 +21,7 @@ driver:
   # Defaults to 'generic/alpine310'
   default_box: 'generic/centos9s'
 platforms:
-  - name: microshfit
+  - name: microshift
     memory: 8192
     cpus: 8
     provider_options:


### PR DESCRIPTION
This change fixes the instance name in the microshfit
target and makes olm uninstall conditional.
