### PR TITLE
add support for install kustomize and local path provisioner

### DIFF
--- a/ansible/roles/ensure_microshift/defaults/main.yml
+++ b/ansible/roles/ensure_microshift/defaults/main.yml
@@ -22,6 +22,8 @@ crio_packages:
   - cri-tools
   - conntrack
 install_olm: true
+install_lpp: true
+install_kustomize: true
 repo_dir: /opt/{{ microshift_user }}
 operator_sdk_url: https://github.com/operator-framework/operator-sdk
 operator_sdk_version: v1.21.0

--- a/ansible/roles/ensure_microshift/files/local-path.patch
+++ b/ansible/roles/ensure_microshift/files/local-path.patch
@@ -1,0 +1,4 @@
+90c90
+<   name: local-path
+---
+>   name: local-storage

--- a/ansible/roles/ensure_microshift/tasks/main.yml
+++ b/ansible/roles/ensure_microshift/tasks/main.yml
@@ -264,3 +264,49 @@
       shell:
         cmd: build/operator-sdk olm install
         chdir: '{{repo_dir}}/operator-sdk'
+
+- name: install kustomize
+  when: install_kustomize | bool
+  tags: kustomize
+  become_user: "{{ microshift_user }}"
+  become: true
+  block:
+    - name: install kustomize
+      shell:
+        cmd: |
+          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+          sudo mv kustomize /usr/bin
+        creates: "/usr/bin/kustomize"
+
+- name: install local path provisioner
+  when: install_lpp | bool
+  tags: lpp
+  become_user: "{{ microshift_user }}"
+  become: true
+  block:
+    - name: create storage path dir
+      become: true
+      become_user: root
+      file:
+        path: '/opt/local-path-provisioner'
+        mode: '777'
+        state: directory
+      register: local_path_directory
+    - name: Download local-path-provisioner manifests
+      when: local_path_directory.changed
+      get_url:
+        url:  https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.22/deploy/local-path-storage.yaml
+        dest: "/home/{{ microshift_user }}/local-path-storage.yaml"
+        mode: '0440'
+    - name: copy manifest patch
+      when: local_path_directory.changed
+      copy:
+        src: local-path.patch
+        dest: "/home/{{ microshift_user }}/local-path.patch"
+    - name: install local-path-provider
+      when: local_path_directory.changed
+      shell:
+        cmd: |
+          cat local-path.patch | patch -p1 local-path-storage.yaml
+          kubectl apply -f local-path-storage.yaml
+        chdir: /home/{{ microshift_user }}

--- a/ansible/roles/ensure_microshift/tasks/main.yml
+++ b/ansible/roles/ensure_microshift/tasks/main.yml
@@ -218,6 +218,7 @@
         cat /var/lib/microshift/resources/kubeadmin/kubeconfig > /home/{{ microshift_user }}/.kube/config
         chown {{ microshift_user }}:{{ microshift_user }} /home/{{ microshift_user }}/.kube/config
 
+# NOTE(sean-k-mooney): we may want to pin the olm version instead of using latest.
 - name: install olm
   when: install_olm | bool
   tags: olm
@@ -253,14 +254,9 @@
       failed_when:
         - olm_status.rc != 0
         - '"Failed to get OLM status: error getting installed OLM version" not in olm_status.stderr'
-    - name: remove olm if installed
-      shell:
-        cmd: build/operator-sdk olm uninstall
-        chdir: '{{repo_dir}}/operator-sdk'
-      register: uninstall_result
-      when:
-        - olm_status.rc == 0
     - name: install olm with sdk
+      when:
+        - olm_status.rc != 0
       shell:
         cmd: build/operator-sdk olm install
         chdir: '{{repo_dir}}/operator-sdk'

--- a/ansible/roles/ensure_microshift/tasks/main.yml
+++ b/ansible/roles/ensure_microshift/tasks/main.yml
@@ -306,3 +306,8 @@
           cat local-path.patch | patch -p1 local-path-storage.yaml
           kubectl apply -f local-path-storage.yaml
         chdir: /home/{{ microshift_user }}
+
+- name: display host ip for ssh login
+  tags : ip
+  debug:
+    var: ansible_host


### PR DESCRIPTION
This change installs kustomize and rancher local path provisioner
by default. they can be disabled with the install_kustomize
and install_lpp role vars.

This change configures the local-path-provisioner
storage class to be that used by the podifed contolplane
poc.
